### PR TITLE
Refresh personal page for a professional data analyst profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
-title: Pablo Github
-email: pablo2@uni-bremen.de
+title: Pablo Freitas | Data Analyst Portfolio
+email: pablofreitag@proton.me
 description: >- # this means to ignore newlines until "baseurl:"
-  Here you can find some old stuff which I did in my university, amateur projects to learn a new skill, journal about learning and much more.
+  Portfolio of Pablo Freitas — Data Analyst specializing in Python, machine learning, speech processing, and data visualization.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username:

--- a/_posts/hate-speech-tool.md
+++ b/_posts/hate-speech-tool.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "My First Data Science Project"
+title: "Hate Speech Detection from Audio"
 date: 2024-09-16
 categories: project
 ---

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ permalink: /about/
 
 ## About Me
 
-Hello, I’m Pablo Freitas, a data scientist passionate about solving real-world problems using data-driven insights. I have experience in machine learning, audio and speech recognition, and Python-based development.
+Hello, I’m Pablo Freitas, a data analyst passionate about solving real-world problems using data-driven insights. I have experience in machine learning, audio and speech recognition, and Python-based development.
 
 I’ve worked on projects involving hate speech detection from audio, where I used advanced tools such as OpenSmile, Whisper, and machine learning models to extract features from audio and classify speech.
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,8 @@ layout: default
 title: "Pablo Freitas - Data Science Portfolio"
 ---
 
-# Welcome to My Data Science Portfolio
+# Pablo Freitas
+**Data Analyst · Python · SQL · Machine Learning**
 
 <!-- ![Visitor Count](https://shields.io/endpoint?url=https://hitcount-server.fly.dev/pfs-db/pfs-db.github.io) -->
 
@@ -25,25 +26,13 @@ I'm a data scientist with expertise in Python, machine learning, and speech reco
 - Description: Collaborated in a group project focused on visualizing wildfire data, using data science techniques to analyze geographical and temporal patterns.
 - [View Code](https://github.com/pfs-db/dataviz-wildfire)
 
-### Haskell Project
-
-- Tools: Haskell
-- Description: Project developed for understanding functional programming concepts.
-- [View Code](https://github.com/pfs-db/pi3-ws23-ueb-pablo)
-
-## Areas of Interesse
+## Areas of Interest
 
 ### Computational Processing of Nheengatú (Modern Tupí)
 
 - Tools: Python
 - Description: Tools and resources for the computational processing of Nheengatú, a Tupi-Guarani language.
 - [View Code](https://github.com/pfs-db/nheengatu)
-
-### Rust Exploration
-
-- Tools: Rust
-- Description: A personal project to explore and learn Rust, with examples and learning resources.
-- [View Code](https://github.com/pfs-db/rust2learn)
 
 ## Skills
 
@@ -54,6 +43,6 @@ I'm a data scientist with expertise in Python, machine learning, and speech reco
 
 ## Contact Me
 
-- Email: pablo2@uni-bremen.de
+- Email: pablofreitag@proton.me
 - LinkedIn: [pablo-freitas-it](https://linkedin.com/in/pablo-freitas-it)
 - GitHub: [pfs-db](https://github.com/pfs-db)


### PR DESCRIPTION
- Rename site title and update meta description to drop "old stuff / amateur" language
- Add professional headline (Data Analyst · Python · SQL · Machine Learning)
- Remove Haskell and Rust learning exercises from portfolio
- Fix typo: "Areas of Interesse" → "Areas of Interest"
- Rename blog post from "My First Data Science Project" to "Hate Speech Detection from Audio"
- Update email to personal Proton address; align "data scientist" → "data analyst" in about.md