### PR TITLE
Update .gitignore for local Ruby/Jekyll dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ _site
 .sass-cache
 .jekyll-cache
 .jekyll-metadata
-vendor
+vendor/
+.bundle/
+Gemfile.lock
+.ruby-version


### PR DESCRIPTION
Add .bundle/, Gemfile.lock, and .ruby-version — all machine-specific artifacts generated when running Jekyll locally with rbenv and bundler.